### PR TITLE
allow hiera to keep looking if value is not found

### DIFF
--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -45,7 +45,14 @@ Puppet::Functions.create_function(:hiera_vault) do
 
     result = vault_get(key, options, context)
 
-    return result
+    # Allow hiera to look beyond vault if the value is not found
+    continue_if_not_found = options['continue_if_not_found'] || false
+
+    if result.nil? and continue_if_not_found
+      context.not_found
+    else
+      return result
+    end
   end
 
 


### PR DESCRIPTION
This change allows for the configuration of whether or not hiera should keep looking if vault returns nil.