### PR TITLE
caching vault object for entire run and closing sockets when done

### DIFF
--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -17,12 +17,21 @@ Puppet::Functions.create_function(:hiera_vault) do
   rescue LoadError => e
     raise Puppet::DataBinding::LookupError, "[hiera-vault] Must install vault gem to use hiera-vault backend"
   end
+  begin
+    require 'debouncer'
+  rescue LoadError => e
+    raise Puppet::DataBinding::LookupError, "[hiera-vault] Must install debouncer gem to use hiera-vault backend"
+  end
+
 
   dispatch :lookup_key do
     param 'Variant[String, Numeric]', :key
     param 'Hash', :options
     param 'Puppet::LookupContext', :context
   end
+
+  @@vault    = Vault::Client.new
+  @@shutdown = Debouncer.new(10) { @@vault.shutdown() }
 
   def lookup_key(key, options, context)
 
@@ -60,9 +69,7 @@ Puppet::Functions.create_function(:hiera_vault) do
     end
 
     begin
-      vault = Vault::Client.new
-
-      vault.configure do |config|
+      @@vault.configure do |config|
         config.address = options['address'] unless options['address'].nil?
         config.token = options['token'] unless options['token'].nil?
         config.ssl_pem_file = options['ssl_pem_file'] unless options['ssl_pem_file'].nil?
@@ -72,13 +79,14 @@ Puppet::Functions.create_function(:hiera_vault) do
         config.ssl_ciphers = options['ssl_ciphers'] if config.respond_to? :ssl_ciphers
       end
 
-      if vault.sys.seal_status.sealed?
+      if @@vault.sys.seal_status.sealed?
         raise Puppet::DataBinding::LookupError, "[hiera-vault] vault is sealed"
       end
 
-      context.explain { "[hiera-vault] Client configured to connect to #{vault.address}" }
+      context.explain { "[hiera-vault] Client configured to connect to #{@@vault.address}" }
     rescue StandardError => e
-      vault = nil
+      @@shutdown.call
+      @@vault = nil
       raise Puppet::DataBinding::LookupError, "[hiera-vault] Skipping backend. Configuration error: #{e}"
     end
 
@@ -93,7 +101,7 @@ Puppet::Functions.create_function(:hiera_vault) do
       context.explain { "[hiera-vault] Looking in path #{path}" }
 
       begin
-        secret = vault.logical.read(path)
+        secret = @@vault.logical.read(path)
       rescue Vault::HTTPConnectionError
         context.explain { "[hiera-vault] Could not connect to read secret: #{path}" }
       rescue Vault::HTTPError => e
@@ -130,7 +138,7 @@ Puppet::Functions.create_function(:hiera_vault) do
         break
       end
     end
-
+    @@shutdown.call
     return answer
   end
 end


### PR DESCRIPTION
This change requires the wf_master version of vault with the exposed 'shutdown' function on the vault client, and introduces a reliance on the debouncer gem.

The result of this change is a single Vault client object per puppet run and the explicit shutdown of opened sockets if there is a gap in hiera lookups for 10 seconds (a new connection will be established if more lookup occur).

The resolves an issue where each hiera lookup to vault was opening a socket which never closed.